### PR TITLE
feat: Make the database name configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+enrollment_report_database: "edxapp"
 enrollment_report_start_date: "{{ lookup('pipe', 'date -I -d \"now - 1 month\"') }}"
 enrollment_report_end_date: "{{ lookup('pipe', 'date -I -d \"now - 1 day\"') }}"
 enrollment_report_path: "/tmp/enrollment-reports"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -124,7 +124,7 @@
 - name: execute scripts
   become: true
   become_user: root
-  shell: "mysql --batch edxapp < {{ item.in }} > {{ item.out }}"  # noqa 301
+  shell: "mysql --batch {{ enrollment_report_database }} < {{ item.in }} > {{ item.out }}"  # noqa 301
   with_items:
     - in: "{{ _enrollment_report_sql.path }}"
       out: "{{ _enrollment_report_outfile }}"


### PR DESCRIPTION
Historically, the name of the Open edX database used to be `edxapp`. With the transition to Tutor in Open edX Maple, the default
database name has changed to `openedx`.

To accommodate both, make the database name configurable.