### PR TITLE
feat: Add optional email server settings

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -161,6 +161,11 @@
     cc: "{{ enrollment_report_mail_cc }}"
     attach: "{{ _enrollment_report_attachments }}"
     charset: utf8
+    host: "{{ enrollment_report_mail_host | default(omit) }}"
+    port: "{{ enrollment_report_mail_port | default(omit) }}"
+    username: "{{ enrollment_report_mail_username | default(omit) }}"
+    password: "{{ enrollment_report_mail_password | default(omit) }}"
+    secure: "{{ enrollment_report_mail_secure | default(omit) }}"
   delegate_to: localhost
   when: enrollment_report_mail_enable
 


### PR DESCRIPTION
Rather than rely on a locally running mail server (which can be assumed in a VM, but not in a container), introduce the following
optional configuration variables:

* `enrollment_report_mail_host`: SMTP server host name
* `enrollment_report_mail_port`: SMTP server port
* `enrollment_report_mail_username`: SMTP AUTH username
* `enrollment_report_mail_password`: SMTP AUTH password
* `enrollment_report_mail_secure`: SMTP encryption options (`always`, `never`, `starttls`, or `try`)

These variables map to the `mail` module's `host`, `port`, `username`, `password`, and `secure` parameters.

Reference:
https://docs.ansible.com/ansible/latest/collections/community/general/mail_module.html