### PR TITLE
feat: Include host name in email subject

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+enrollment_report_hostname: "{{ ansible_host }}"
 enrollment_report_database: "edxapp"
 enrollment_report_start_date: "{{ lookup('pipe', 'date -I -d \"now - 1 month\"') }}"
 enrollment_report_end_date: "{{ lookup('pipe', 'date -I -d \"now - 1 day\"') }}"
@@ -6,7 +7,6 @@ enrollment_report_path: "/tmp/enrollment-reports"
 enrollment_report_grade_percent: 80
 enrollment_report_format: tsv
 enrollment_report_mail_enable: false
-enrollment_report_mail_subject: "Enrollment reports for {{ enrollment_report_start_date }} - {{ enrollment_report_end_date }}"
 enrollment_report_mail_from: ""
 enrollment_report_mail_to: []
 enrollment_report_mail_cc: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -155,7 +155,7 @@
 
 - name: send out enrollment reports
   mail:
-    subject: "{{ enrollment_report_mail_subject }}"
+    subject: "Enrollment reports for {{ enrollment_report_hostname }} ({{ enrollment_report_start_date }} - {{ enrollment_report_end_date }})"
     from: "{{ enrollment_report_mail_from }}"
     to: "{{ enrollment_report_mail_to }}"
     cc: "{{ enrollment_report_mail_cc }}"


### PR DESCRIPTION
If enrollment reports are being generated on multiple systems, it helps to be able to tell them apart by source.

Thus, include a configurable host name in the email subject. This defaults to `ansible_host`, but when used in conjunction with
[tutor-contrib-enrollmentreports](https://github.com/hastexo/tutor-contrib-enrollmentreports/) it should be populated with the `LMS_HOST` variable.