### PR TITLE
feat: Make the enrollment report frequency configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,7 @@
 ---
 enrollment_report_hostname: "{{ ansible_host }}"
 enrollment_report_database: "edxapp"
-enrollment_report_start_date: "{{ lookup('pipe', 'date -I -d \"now - 1 month\"') }}"
-enrollment_report_end_date: "{{ lookup('pipe', 'date -I -d \"now - 1 day\"') }}"
+enrollment_report_frequency: "monthly"
 enrollment_report_path: "/tmp/enrollment-reports"
 enrollment_report_grade_percent: 80
 enrollment_report_format: tsv

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,25 @@
 ---
-- name: sanitize start and end date facts
+- name: fail on incorrectly set frequency
+  fail:
+    msg: "Incorrect value for enrollment_report_frequency: {{ enrollment_report_frequency }} (must be 'monthly' or 'weekly')."
+  when: 'enrollment_report_frequency not in ["monthly", "weekly"]'
+
+- name: set start date (monthly run)
   set_fact:
-    _enrollment_report_start_date: "{{ lookup('pipe', 'date +\"%Y-%m-%d %H:%M:%S\" -d \"' + enrollment_report_start_date|quote + ' 00:00:00\"') }}"
-    _enrollment_report_end_date: "{{ lookup('pipe', 'date +\"%Y-%m-%d %H:%M:%S\" -d \"' + enrollment_report_end_date|quote + ' 23:59:59\"') }}"
+    _enrollment_report_start_date: "{{ lookup('pipe', 'date +\"%Y-%m-%d\" -d \"today - 1 month\"') }}"
+    _enrollment_report_start_datetime: "{{ lookup('pipe', 'date +\"%Y-%m-%d %H:%M:%S\" -d \"today - 1 month 00:00:00\"') }}"
+  when: enrollment_report_frequency == "monthly"
+
+- name: set start date (weekly run)
+  set_fact:
+    _enrollment_report_start_date: "{{ lookup('pipe', 'date +\"%Y-%m-%d\" -d \"today - 1 week\"') }}"
+    _enrollment_report_start_datetime: "{{ lookup('pipe', 'date +\"%Y-%m-%d %H:%M:%S\" -d \"today - 1 week 00:00:00\"') }}"
+  when: enrollment_report_frequency == "weekly"
+
+- name: set end date
+  set_fact:
+    _enrollment_report_end_date: "{{ lookup('pipe', 'date +\"%Y-%m-%d \" -d \"yesterday\"') }}"
+    _enrollment_report_end_datetime: "{{ lookup('pipe', 'date +\"%Y-%m-%d %H:%M:%S\" -d \"yesterday 23:59:59\"') }}"
 
 - name: define facts for TSV output
   set_fact:
@@ -23,12 +40,12 @@
 
 - name: set output file names
   set_fact:
-    _enrollment_report_filename: "enrollment_report_{{ enrollment_report_start_date }}_{{ enrollment_report_end_date }}{{ _enrollment_report_file_suffix }}"
-    _enrollment_report_pass_filename: "pass_report_{{ enrollment_report_start_date }}_{{ enrollment_report_end_date }}{{ _enrollment_report_file_suffix }}"
-    _enrollment_report_percent_filename: "percent_report_{{ enrollment_report_start_date }}_{{ enrollment_report_end_date }}{{ _enrollment_report_file_suffix }}"
-    _enrollment_report_historical_filename: "enrollment_report_historical_{{ enrollment_report_end_date }}{{ _enrollment_report_file_suffix }}"
-    _enrollment_report_pass_historical_filename: "pass_report_historical_{{ enrollment_report_end_date }}{{ _enrollment_report_file_suffix }}"
-    _enrollment_report_percent_historical_filename: "percent_report_historical_{{ enrollment_report_end_date }}{{ _enrollment_report_file_suffix }}"
+    _enrollment_report_filename: "enrollment_report_{{ _enrollment_report_start_date }}_{{ _enrollment_report_end_date }}{{ _enrollment_report_file_suffix }}"
+    _enrollment_report_pass_filename: "pass_report_{{ _enrollment_report_start_date }}_{{ _enrollment_report_end_date }}{{ _enrollment_report_file_suffix }}"
+    _enrollment_report_percent_filename: "percent_report_{{ _enrollment_report_start_date }}_{{ _enrollment_report_end_date }}{{ _enrollment_report_file_suffix }}"
+    _enrollment_report_historical_filename: "enrollment_report_historical_{{ _enrollment_report_end_date }}{{ _enrollment_report_file_suffix }}"
+    _enrollment_report_pass_historical_filename: "pass_report_historical_{{ _enrollment_report_end_date }}{{ _enrollment_report_file_suffix }}"
+    _enrollment_report_percent_historical_filename: "percent_report_historical_{{ _enrollment_report_end_date }}{{ _enrollment_report_file_suffix }}"
 
 - name: set output file paths
   set_fact:
@@ -155,7 +172,7 @@
 
 - name: send out enrollment reports
   mail:
-    subject: "Enrollment reports for {{ enrollment_report_hostname }} ({{ enrollment_report_start_date }} - {{ enrollment_report_end_date }})"
+    subject: "Enrollment reports for {{ enrollment_report_hostname }} ({{ _enrollment_report_start_date }} - {{ _enrollment_report_end_date }})"
     from: "{{ enrollment_report_mail_from }}"
     to: "{{ enrollment_report_mail_to }}"
     cc: "{{ enrollment_report_mail_cc }}"

--- a/templates/enrollment-report-historical.sql.j2
+++ b/templates/enrollment-report-historical.sql.j2
@@ -11,7 +11,7 @@ SELECT
 FROM
     student_courseenrollment
 WHERE
-    created<='{{ enrollment_report_end_date }}'
+    created<='{{ _enrollment_report_end_datetime }}'
 GROUP BY
     org, course, run, year, month
 ORDER BY

--- a/templates/enrollment-report.sql.j2
+++ b/templates/enrollment-report.sql.j2
@@ -18,7 +18,7 @@ LEFT JOIN
     ON b.user_id = c.user_id
     AND b.course_id = c.course_id
 WHERE
-    b.created BETWEEN '{{ _enrollment_report_start_date }}' AND '{{ _enrollment_report_end_date }}'
+    b.created BETWEEN '{{ _enrollment_report_start_datetime }}' AND '{{ _enrollment_report_end_datetime }}'
 ORDER BY
     org, course, run, b.created
 ;

--- a/templates/enrollments-per-email.sql.j2
+++ b/templates/enrollments-per-email.sql.j2
@@ -14,7 +14,7 @@ LEFT JOIN
     student_courseenrollment e
     ON u.id = e.user_id
 WHERE
-    e.created BETWEEN '{{ _enrollment_report_start_date }}' AND '{{ _enrollment_report_end_date }}'
+    e.created BETWEEN '{{ _enrollment_report_start_datetime }}' AND '{{ _enrollment_report_end_datetime }}'
 GROUP BY
     email, username
 ORDER BY

--- a/templates/grade-report-pass-historical.sql.j2
+++ b/templates/grade-report-pass-historical.sql.j2
@@ -14,7 +14,7 @@ INNER JOIN
     ON au.id = pcg.user_id
 WHERE
     pcg.letter_grade='Pass'
-    AND pcg.created<='{{ enrollment_report_end_date }}'
+    AND pcg.created<='{{ _enrollment_report_end_datetime }}'
 GROUP BY
     org, course, run, year, month
 ORDER BY

--- a/templates/grade-report-pass.sql.j2
+++ b/templates/grade-report-pass.sql.j2
@@ -12,7 +12,7 @@ INNER JOIN
     auth_user au
     ON au.id = pcg.user_id
 WHERE
-    pcg.created BETWEEN '{{ enrollment_report_start_date }}' AND '{{ enrollment_report_end_date }}'
+    pcg.created BETWEEN '{{ _enrollment_report_start_datetime }}' AND '{{ _enrollment_report_end_datetime }}'
 ORDER BY
     org, course, run, pcg.created
 ;

--- a/templates/grade-report-percent-historical.sql.j2
+++ b/templates/grade-report-percent-historical.sql.j2
@@ -14,7 +14,7 @@ INNER JOIN
     ON au.id = pcg.user_id
 WHERE
     pcg.percent_grade>=ROUND({{ enrollment_report_grade_percent / 100 }},2)
-    AND pcg.created<='{{ enrollment_report_end_date }}'
+    AND pcg.created<='{{ _enrollment_report_end_datetime }}'
 GROUP BY
     org, course, run, year, month
 ORDER BY

--- a/templates/grade-report-percent.sql.j2
+++ b/templates/grade-report-percent.sql.j2
@@ -13,7 +13,7 @@ INNER JOIN
     auth_user au
     ON au.id = pcg.user_id
 WHERE
-    pcg.created BETWEEN '{{ enrollment_report_start_date }}' AND '{{ enrollment_report_end_date }}'
+    pcg.created BETWEEN '{{ _enrollment_report_start_datetime }}' AND '{{ _enrollment_report_end_datetime }}'
 ORDER BY
     org, course, run, pcg.created
 ;


### PR DESCRIPTION
Previously, enrollment reports would only ever be generated monthly.

With this change, we can set a new variable,
"enrollment_report_frequency", which can be "monthly" or "weekly".

If set to "monthly" (the default), the playbook retains the previous
behaviour of generating a report covering enrollments from the past
month. If set to "weekly", it generates a weekly report instead.
