### PR TITLE
feat: Add reports that summarize lab utilization times

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,18 +43,22 @@
     _enrollment_report_filename: "enrollment_report_{{ _enrollment_report_start_date }}_{{ _enrollment_report_end_date }}{{ _enrollment_report_file_suffix }}"
     _enrollment_report_pass_filename: "pass_report_{{ _enrollment_report_start_date }}_{{ _enrollment_report_end_date }}{{ _enrollment_report_file_suffix }}"
     _enrollment_report_percent_filename: "percent_report_{{ _enrollment_report_start_date }}_{{ _enrollment_report_end_date }}{{ _enrollment_report_file_suffix }}"
+    _enrollment_report_lab_filename: "lab_report_{{ _enrollment_report_start_date }}_{{ _enrollment_report_end_date }}{{ _enrollment_report_file_suffix }}"
     _enrollment_report_historical_filename: "enrollment_report_historical_{{ _enrollment_report_end_date }}{{ _enrollment_report_file_suffix }}"
     _enrollment_report_pass_historical_filename: "pass_report_historical_{{ _enrollment_report_end_date }}{{ _enrollment_report_file_suffix }}"
     _enrollment_report_percent_historical_filename: "percent_report_historical_{{ _enrollment_report_end_date }}{{ _enrollment_report_file_suffix }}"
+    _enrollment_report_lab_historical_filename: "lab_report_historical_{{ _enrollment_report_end_date }}{{ _enrollment_report_file_suffix }}"
 
 - name: set output file paths
   set_fact:
     _enrollment_report_outfile: "{{ _enrollment_report_directory.path }}/{{ _enrollment_report_filename }}"
     _enrollment_report_pass_outfile: "{{ _enrollment_report_directory.path }}/{{ _enrollment_report_pass_filename }}"
     _enrollment_report_percent_outfile: "{{ _enrollment_report_directory.path }}/{{ _enrollment_report_percent_filename }}"
+    _enrollment_report_lab_outfile: "{{ _enrollment_report_directory.path }}/{{ _enrollment_report_lab_filename }}"
     _enrollment_report_historical_outfile: "{{ _enrollment_report_directory.path }}/{{ _enrollment_report_historical_filename }}"
     _enrollment_report_pass_historical_outfile: "{{ _enrollment_report_directory.path }}/{{ _enrollment_report_pass_historical_filename }}"
     _enrollment_report_percent_historical_outfile: "{{ _enrollment_report_directory.path }}/{{ _enrollment_report_percent_historical_filename }}"
+    _enrollment_report_lab_historical_outfile: "{{ _enrollment_report_directory.path }}/{{ _enrollment_report_lab_historical_filename }}"
 
 - name: create tempfile for enrollment report SQL
   tempfile:
@@ -128,6 +132,30 @@
     src: grade-report-percent-historical.sql.j2
     mode: 0644
 
+- name: create tempfile for "lab" report SQL
+  tempfile:
+    state: file
+    suffix: .sql
+  register: _enrollment_report_lab_sql
+
+- name: populate "lab" report SQL
+  template:
+    dest: "{{ _enrollment_report_lab_sql.path }}"
+    src: lab-report.sql.j2
+    mode: 0644
+
+- name: create tempfile for historical "lab" report SQL
+  tempfile:
+    state: file
+    suffix: .sql
+  register: _enrollment_report_lab_historical_sql
+
+- name: populate historical "lab" report SQL
+  template:
+    dest: "{{ _enrollment_report_lab_historical_sql.path }}"
+    src: lab-report-historical.sql.j2
+    mode: 0644
+
 - name: execute scripts
   become: true
   become_user: root
@@ -139,12 +167,16 @@
       out: "{{ _enrollment_report_pass_outfile }}"
     - in: "{{ _enrollment_report_percent_sql.path }}"
       out: "{{ _enrollment_report_percent_outfile }}"
+    - in: "{{ _enrollment_report_lab_sql.path }}"
+      out: "{{ _enrollment_report_lab_outfile }}"
     - in: "{{ _enrollment_report_historical_sql.path }}"
       out: "{{ _enrollment_report_historical_outfile }}"
     - in: "{{ _enrollment_report_pass_historical_sql.path }}"
       out: "{{ _enrollment_report_pass_historical_outfile }}"
     - in: "{{ _enrollment_report_percent_historical_sql.path }}"
       out: "{{ _enrollment_report_percent_historical_outfile }}"
+    - in: "{{ _enrollment_report_lab_historical_sql.path }}"
+      out: "{{ _enrollment_report_lab_historical_outfile }}"
 
 - name: ensure output directory exists
   file:
@@ -165,9 +197,11 @@
       - "{{ enrollment_report_path }}/{{ _enrollment_report_filename }}"
       - "{{ enrollment_report_path }}/{{ _enrollment_report_pass_filename }}"
       - "{{ enrollment_report_path }}/{{ _enrollment_report_percent_filename }}"
+      - "{{ enrollment_report_path }}/{{ _enrollment_report_lab_filename }}"
       - "{{ enrollment_report_path }}/{{ _enrollment_report_historical_filename }}"
       - "{{ enrollment_report_path }}/{{ _enrollment_report_pass_historical_filename }}"
       - "{{ enrollment_report_path }}/{{ _enrollment_report_percent_historical_filename }}"
+      - "{{ enrollment_report_path }}/{{ _enrollment_report_lab_historical_filename }}"
   when: enrollment_report_mail_enable
 
 - name: send out enrollment reports
@@ -201,6 +235,8 @@
     - "{{ _enrollment_report_sql.path }}"
     - "{{ _enrollment_report_pass_sql.path }}"
     - "{{ _enrollment_report_percent_sql.path }}"
+    - "{{ _enrollment_report_lab_sql.path }}"
     - "{{ _enrollment_report_historical_sql.path }}"
     - "{{ _enrollment_report_pass_historical_sql.path }}"
     - "{{ _enrollment_report_percent_historical_sql.path }}"
+    - "{{ _enrollment_report_lab_historical_sql.path }}"

--- a/templates/lab-report-historical.sql.j2
+++ b/templates/lab-report-historical.sql.j2
@@ -1,0 +1,33 @@
+-- -*- mode: sql; -*-
+-- vim: ft=sql
+SELECT
+  u.email,
+  LCASE(SUBSTRING_INDEX(SUBSTRING_INDEX(s.course_id, '+', 1), ':', -1)) AS org,
+  LCASE(SUBSTRING_INDEX(SUBSTRING_INDEX(s.course_id, '+', 2), '+', -1)) AS course,
+  LCASE(SUBSTRING_INDEX(s.course_id, '+', -1)) AS run,
+  YEAR(sl.suspend_timestamp) AS 'year',
+  MONTH(sl.suspend_timestamp) AS 'month',
+  SUM(TIMESTAMPDIFF(SECOND,
+                    sl.launch_timestamp,
+                    sl.suspend_timestamp)) AS lab_seconds
+FROM hastexo_stacklog AS sl
+  INNER JOIN hastexo_stack AS s ON sl.stack_id=s.id
+  INNER JOIN auth_user u ON s.learner_id=u.id
+WHERE
+  sl.status='SUSPEND_COMPLETE'
+  AND sl.suspend_timestamp<='{{ _enrollment_report_end_datetime }}'
+GROUP BY
+  u.email,
+  org,
+  course,
+  run,
+  year,
+  month
+ORDER BY
+  year,
+  month,
+  org,
+  course,
+  run,
+  u.email
+;

--- a/templates/lab-report.sql.j2
+++ b/templates/lab-report.sql.j2
@@ -1,0 +1,27 @@
+-- -*- mode: sql; -*-
+-- vim: ft=sql
+SELECT
+  u.email,
+  LCASE(SUBSTRING_INDEX(SUBSTRING_INDEX(s.course_id, '+', 1), ':', -1)) AS org,
+  LCASE(SUBSTRING_INDEX(SUBSTRING_INDEX(s.course_id, '+', 2), '+', -1)) AS course,
+  LCASE(SUBSTRING_INDEX(s.course_id, '+', -1)) AS run,
+  SUM(TIMESTAMPDIFF(SECOND,
+                    sl.launch_timestamp,
+                    sl.suspend_timestamp)) AS lab_seconds
+FROM hastexo_stacklog AS sl
+  INNER JOIN hastexo_stack AS s ON sl.stack_id=s.id
+  INNER JOIN auth_user u ON s.learner_id=u.id
+WHERE
+  sl.status='SUSPEND_COMPLETE'
+  AND sl.suspend_timestamp BETWEEN '{{ _enrollment_report_start_datetime }}' AND '{{ _enrollment_report_end_datetime }}'
+GROUP BY
+  u.email,
+  org,
+  course,
+  run
+ORDER BY
+  org,
+  course,
+  run,
+  u.email
+;


### PR DESCRIPTION
Expand the tasks and templates such that we get a report on how much lab time learners have used.

As with the other reports, include one that covers only the current period, and a historical one that covers everything up to the current date.