### PR TITLE
build: Add bumpversion support

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,5 @@
+[bumpversion]
+commit = True
+tag = True
+message = build: Version {new_version}
+current_version = 2.0.0

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,4 +2,4 @@
 commit = True
 tag = True
 message = build: Version {new_version}
-current_version = 2.0.0
+current_version = 2.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -16,3 +16,16 @@ commands = yamllint {toxinidir}
 skip_install = True
 deps = gitlint
 commands = gitlint {posargs}
+
+[testenv:bumpversion]
+skip_install = True
+passenv =
+  # Git can only find its global configuration if it knows where the
+  # user's HOME is.
+  HOME
+  # If we set sign_tags in .bumpversion.cfg, we need to pass in the
+  # GnuPG agent reference to avoid having to retype the passphrase for
+  # an already-cached private key.
+  GPG_AGENT_INFO
+deps = bump2version
+commands = bump2version {posargs}


### PR DESCRIPTION
In order to facilitate tagging in view of https://github.com/hastexo/tutor-contrib-enrollmentreports/pull/21, add a `bumpversion` testenv and set the current version to 2.0.0, as that is the current version of that plugin.