### PR TITLE
build: Add Python 3.12 to the build/test matrix

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -12,7 +12,8 @@ jobs:
       matrix:
         python-version:
           - '3.8'
-          - '3.9'
+          - '3.10'
+          - '3.12'
 
     steps:
       - name: Check out code

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 [tox]
 minversion = 2.0
-envlist = py38,py310
+envlist = py38,py310,py312
 skipsdist = True
 
 [gh-actions]
 python =
     3.8: gitlint,py38
     3.10: gitlint,py310
+    3.12: gitlint,py312
 
 [testenv]
 deps = yamllint


### PR DESCRIPTION
Add a py312 test environment to tox.ini, and add Python 3.12 (and 3.10) to the GitHub Actions build matrix.
