### PR TITLE
build: Add gitlint testenv to tox and GitHub Actions workflow

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -18,6 +18,10 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          # Checkout a pull request's HEAD commit instead of the merge
+          # commit, so that gitlint lints the correct commit message.
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.0
-envlist = py310,py311,py312
+envlist = gitlint,py{310,311,312}
 skipsdist = True
 
 [gh-actions]


### PR DESCRIPTION
Add the tox `gitlint` testenv to the list of testenvs invoked by the GitHub Actions workflow, so we can catch sub-standard commit messages in the CI pipeline.
