### PR TITLE
docs: Update README to mention repo move

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ An **experimental**
 generating enrollment reports for an Open edX platform.
 
 This role is meant to be used exclusively by the
-[`enrollmentreports`](https://github.com/hastexo/tutor-contrib-enrollmentreports/)
+[`enrollmentreports`](https://github.com/cleura/tutor-contrib-enrollmentreports/)
 plugin for [Tutor](https://docs.tutor.overhang.io).
+
+This repository was previously hosted under the `hastexo` GitHub organization, and moved to `cleura` in December 2025 as part of a routine repository consolidation.
 


### PR DESCRIPTION
Mention that the repo has been moved from the hastexo to the cleura org.

Related: https://github.com/cleura/tutor-contrib-enrollmentreports/pull/42
