### PR TITLE
fix: Update lab report SQL templates to refer to stackamole, not hastexo

### DIFF
--- a/templates/lab-report-historical-by-learner.sql.j2
+++ b/templates/lab-report-historical-by-learner.sql.j2
@@ -7,8 +7,8 @@ SELECT
   SUM(TIMESTAMPDIFF(SECOND,
                     sl.launch_timestamp,
                     sl.suspend_timestamp)) AS lab_seconds
-FROM hastexo_stacklog AS sl
-  INNER JOIN hastexo_stack AS s ON sl.stack_id=s.id
+FROM stackamole_stacklog AS sl
+  INNER JOIN stackamole_stack AS s ON sl.stack_id=s.id
   INNER JOIN auth_user u ON s.learner_id=u.id
 WHERE
   sl.status='SUSPEND_COMPLETE'

--- a/templates/lab-report-historical.sql.j2
+++ b/templates/lab-report-historical.sql.j2
@@ -10,8 +10,8 @@ SELECT
   SUM(TIMESTAMPDIFF(SECOND,
                     sl.launch_timestamp,
                     sl.suspend_timestamp)) AS lab_seconds
-FROM hastexo_stacklog AS sl
-  INNER JOIN hastexo_stack AS s ON sl.stack_id=s.id
+FROM stackamole_stacklog AS sl
+  INNER JOIN stackamole_stack AS s ON sl.stack_id=s.id
   INNER JOIN auth_user u ON s.learner_id=u.id
 WHERE
   sl.status='SUSPEND_COMPLETE'

--- a/templates/lab-report.sql.j2
+++ b/templates/lab-report.sql.j2
@@ -8,8 +8,8 @@ SELECT
   SUM(TIMESTAMPDIFF(SECOND,
                     sl.launch_timestamp,
                     sl.suspend_timestamp)) AS lab_seconds
-FROM hastexo_stacklog AS sl
-  INNER JOIN hastexo_stack AS s ON sl.stack_id=s.id
+FROM stackamole_stacklog AS sl
+  INNER JOIN stackamole_stack AS s ON sl.stack_id=s.id
   INNER JOIN auth_user u ON s.learner_id=u.id
 WHERE
   sl.status='SUSPEND_COMPLETE'


### PR DESCRIPTION
If the target Open edX environment has upgraded the hastexo XBlock to
the Stackamole XBlock, the lab report fails.

Update the SQL templates to refer to the correct table name.
